### PR TITLE
Correct riemann spelling

### DIFF
--- a/10/riemann/examplecom/etc/email.clj
+++ b/10/riemann/examplecom/etc/email.clj
@@ -60,7 +60,7 @@
               footer))
           events)))
 
-(def email (mailer {:from "reimann@example.com"
+(def email (mailer {:from "riemann@example.com"
                     :subject (fn [events] (format-subject events))
                     :body (fn [events] (format-body events))
                     }))

--- a/11-13/riemann/examplecom/etc/email.clj
+++ b/11-13/riemann/examplecom/etc/email.clj
@@ -60,7 +60,7 @@
               footer))
           events)))
 
-(def email (mailer {:from "reimann@example.com"
+(def email (mailer {:from "riemann@example.com"
                     :subject (fn [events] (format-subject events))
                     :body (fn [events] (format-body events))
                     }))

--- a/3/riemann/examplecom/etc/email.clj
+++ b/3/riemann/examplecom/etc/email.clj
@@ -1,4 +1,4 @@
 (ns examplecom.etc.email
   (:require [riemann.email :refer :all]))
 
-(def email (mailer {:from "reimann@example.com"}))
+(def email (mailer {:from "riemann@example.com"}))

--- a/4/riemann/examplecom/etc/email.clj
+++ b/4/riemann/examplecom/etc/email.clj
@@ -1,4 +1,4 @@
 (ns examplecom.etc.email
   (:require [riemann.email :refer :all]))
 
-(def email (mailer {:from "reimann@example.com"}))
+(def email (mailer {:from "riemann@example.com"}))

--- a/5-6/riemann/examplecom/etc/email.clj
+++ b/5-6/riemann/examplecom/etc/email.clj
@@ -1,4 +1,4 @@
 (ns examplecom.etc.email
   (:require [riemann.email :refer :all]))
 
-(def email (mailer {:from "reimann@example.com"}))
+(def email (mailer {:from "riemann@example.com"}))

--- a/7/riemann/examplecom/etc/email.clj
+++ b/7/riemann/examplecom/etc/email.clj
@@ -1,4 +1,4 @@
 (ns examplecom.etc.email
   (:require [riemann.email :refer :all]))
 
-(def email (mailer {:from "reimann@example.com"}))
+(def email (mailer {:from "riemann@example.com"}))

--- a/8/riemann/examplecom/etc/email.clj
+++ b/8/riemann/examplecom/etc/email.clj
@@ -1,4 +1,4 @@
 (ns examplecom.etc.email
   (:require [riemann.email :refer :all]))
 
-(def email (mailer {:from "reimann@example.com"}))
+(def email (mailer {:from "riemann@example.com"}))

--- a/9/riemann/examplecom/etc/email.clj
+++ b/9/riemann/examplecom/etc/email.clj
@@ -1,4 +1,4 @@
 (ns examplecom.etc.email
   (:require [riemann.email :refer :all]))
 
-(def email (mailer {:from "reimann@example.com"}))
+(def email (mailer {:from "riemann@example.com"}))


### PR DESCRIPTION
This is part of updating aom book, correcting riemann spelling in email.clj files.